### PR TITLE
Add custom build script for runtime

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -127,6 +127,7 @@ authors = ['Anonymous']
 edition = '2018'
 name = 'haski-runtime'
 version = '2.0.0'
+build = "build.rs"
 
 [features]
 default = ['std']


### PR DESCRIPTION
without the build.rs file, `cargo build` in the runtime project folder will not export compact wasm file in the wbuild folder.